### PR TITLE
uplift to net8.0 adapt std plugin export sample file

### DIFF
--- a/ShippedItemInstanceConverter.csproj
+++ b/ShippedItemInstanceConverter.csproj
@@ -1,15 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AgGatewayADAPTFramework" Version="2.7.0" />
-    <PackageReference Include="AgGatewayADMPlugin" Version="2.3.3" />
-    <PackageReference Include="AgGatewayISOPlugin" Version="4.0.0" />
-    <PackageReference Include="AgGatewayShippedItemInstancePlugin" Version="1.1.0" />
+    <PackageReference Include="AgGateway.ADAPT.StandardPlugin" Version="0.9.7" />
+    <PackageReference Include="AgGatewayADAPTFramework" Version="3.1.0" />
+    <PackageReference Include="AgGatewayADMPlugin" Version="3.0.1" />
+    <PackageReference Include="AgGatewayISOPlugin" Version="5.6.1" /> 
+    <PackageReference Include="AgGatewayShippedItemInstancePlugin" Version="4.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="0.7.2-preview" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/sampleV4Files/shippedItemInstanceList_response_shipmentId_7302_glnid_1369458675000.json
+++ b/sampleV4Files/shippedItemInstanceList_response_shipmentId_7302_glnid_1369458675000.json
@@ -1,0 +1,1808 @@
+[
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "3230Enlist SDBX ESCALATE SDS+ BEANS",
+            "gtinid": "",
+            "varietyName": "3230Enlist",
+            "productName": "3230Enlist",
+            "itemTreatment": {
+                "id": "ESCALATE SDS+",
+                "name": "ESCALATE SDS+",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 135
+        },
+        "description": {
+            "content": "3230Enlist-E22388816X",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "S",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Soybeans"
+                    },
+                    {
+                        "content": "SDBX",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "E22388816X",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-1",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "52814c7c-7b3b-4e67-9911-290a0f92046a",
+        "_rid": "GqBGAMy2ZFUBAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUBAAAAAAAAAA==/",
+        "_etag": "\"7400497f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "3510Enlist SDBX ESCALATE BEANS",
+            "gtinid": "",
+            "varietyName": "3510Enlist",
+            "productName": "3510Enlist",
+            "itemTreatment": {
+                "id": "ESCALATE",
+                "name": "ESCALATE",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 135
+        },
+        "description": {
+            "content": "3510Enlist-F2212127X",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "S",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Soybeans"
+                    },
+                    {
+                        "content": "SDBX",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "F2212127X",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-2",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "dc70e971-6ad2-4a28-881f-c02d5beab463",
+        "_rid": "GqBGAMy2ZFUCAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUCAAAAAAAAAA==/",
+        "_etag": "\"74004a7f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "XL 6081AM BAG ESCALATE MED FLAT CORN",
+            "gtinid": "",
+            "varietyName": "XL 6081AM ",
+            "productName": "XL 6081AM ",
+            "itemTreatment": {
+                "id": "ESCALATE",
+                "name": "ESCALATE",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 8
+        },
+        "description": {
+            "content": "XL 6081AM -S116FF",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "C",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Corn"
+                    },
+                    {
+                        "content": "XL",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "S116FF",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-3",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "c373a78b-ff3d-4ac4-bb3b-a50a4a82cd41",
+        "_rid": "GqBGAMy2ZFUDAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUDAAAAAAAAAA==/",
+        "_etag": "\"74004b7f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "XL 6241QR BAG ESCALATE MED FLAT CORN",
+            "gtinid": "",
+            "varietyName": "XL 6241QR ",
+            "productName": "XL 6241QR ",
+            "itemTreatment": {
+                "id": "ESCALATE",
+                "name": "ESCALATE",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Acre",
+            "content": 24
+        },
+        "description": {
+            "content": "XL 6241QR -S260FF",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "C",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Corn"
+                    },
+                    {
+                        "content": "XL",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "S260FF",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-4",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "0af7f985-fffa-4f9f-abae-59e9edaec7bd",
+        "_rid": "GqBGAMy2ZFUEAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUEAAAAAAAAAA==/",
+        "_etag": "\"74004c7f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "6374VT2P BAG ESCALATE MED FLAT CORN",
+            "gtinid": "",
+            "varietyName": "6374VT2P B",
+            "productName": "6374VT2P B",
+            "itemTreatment": {
+                "id": "ESCALATE",
+                "name": "ESCALATE",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 24
+        },
+        "description": {
+            "content": "6374VT2P B-S65FF",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "C",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Corn"
+                    },
+                    {
+                        "content": "VT2P",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "S65FF",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-5",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "093c2602-689a-4702-a83b-3de2c74eba3b",
+        "_rid": "GqBGAMy2ZFUFAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUFAAAAAAAAAA==/",
+        "_etag": "\"74004d7f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "6414VT2P BAG ESCALATE MED FLAT CORN",
+            "gtinid": "",
+            "varietyName": "6414VT2P B",
+            "productName": "6414VT2P B",
+            "itemTreatment": {
+                "id": "ESCALATE",
+                "name": "ESCALATE",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 32
+        },
+        "description": {
+            "content": "6414VT2P B-E181FF",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "C",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Corn"
+                    },
+                    {
+                        "content": "VT2P",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "E181FF",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-6",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "5854914c-f97c-475e-8c7a-162a7c09cdb0",
+        "_rid": "GqBGAMy2ZFUGAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUGAAAAAAAAAA==/",
+        "_etag": "\"74004e7f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "3830Enlist SDBX ESCALATE SDS+ BEANS",
+            "gtinid": "",
+            "varietyName": "3830Enlist",
+            "productName": "3830Enlist",
+            "itemTreatment": {
+                "id": "ESCALATE SDS+",
+                "name": "ESCALATE SDS+",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 45
+        },
+        "description": {
+            "content": "3830Enlist-F22121214X",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "S",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Soybeans"
+                    },
+                    {
+                        "content": "SDBX",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "F22121214X",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-7",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "92e67687-f93c-413a-a47d-b35e71bfa5fb",
+        "_rid": "GqBGAMy2ZFUHAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUHAAAAAAAAAA==/",
+        "_etag": "\"74004f7f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "4320Enlist SDBX EXCALATE SDS+ BEANS",
+            "gtinid": "",
+            "varietyName": "4320Enlist",
+            "productName": "4320Enlist",
+            "itemTreatment": {
+                "id": "ESCALATE SDS+",
+                "name": "ESCALATE SDS+",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 225
+        },
+        "description": {
+            "content": "4320Enlist-A22242312X",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "S",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Soybeans"
+                    },
+                    {
+                        "content": "SDBX",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "A22242312X",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-8",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "7be4c59e-1a87-430b-97a6-dcb8fdc3b848",
+        "_rid": "GqBGAMy2ZFUIAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUIAAAAAAAAAA==/",
+        "_etag": "\"7400507f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "4030Enlist SDBX ESCALATE SDS+ BEANS",
+            "gtinid": "",
+            "varietyName": "4030Enlist",
+            "productName": "4030Enlist",
+            "itemTreatment": {
+                "id": "ESCALATE SDS+",
+                "name": "ESCALATE SDS+",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 180
+        },
+        "description": {
+            "content": "4030Enlist-B2227251X",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "S",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Soybeans"
+                    },
+                    {
+                        "content": "SDBX",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "B2227251X",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-9",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "95186b33-d29f-4ae4-b886-c076d2208785",
+        "_rid": "GqBGAMy2ZFUJAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUJAAAAAAAAAA==/",
+        "_etag": "\"7400517f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "3030Enlist SDBX ESCALATE SDS+ BEANS",
+            "gtinid": "",
+            "varietyName": "3030Enlist",
+            "productName": "3030Enlist",
+            "itemTreatment": {
+                "id": "ESCALATE SDS+",
+                "name": "ESCALATE SDS+",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 90
+        },
+        "description": {
+            "content": "3030Enlist-E2238579X",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "S",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Soybeans"
+                    },
+                    {
+                        "content": "SDBX",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "E2238579X",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-10",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "6d71c898-bf5c-4416-8929-5b1063387f5e",
+        "_rid": "GqBGAMy2ZFUKAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUKAAAAAAAAAA==/",
+        "_etag": "\"7400527f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "Beck's",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "4030Enlist SDBX ILEVO TWO BEANS",
+            "gtinid": "",
+            "varietyName": "4030Enlist",
+            "productName": "4030Enlist",
+            "itemTreatment": {
+                "id": "ILEVO",
+                "name": "ILEVO",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 45
+        },
+        "description": {
+            "content": "4030Enlist-B2223136XI",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "S",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Soybeans"
+                    },
+                    {
+                        "content": "SDBX",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "B2223136XI",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-11",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "9c60514c-cbb6-47b8-8b86-6c15fd60c84d",
+        "_rid": "GqBGAMy2ZFULAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFULAAAAAAAAAA==/",
+        "_etag": "\"7400537f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "AgriGold",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "A6544-VT2RIB",
+            "gtinid": "",
+            "varietyName": "A6544",
+            "productName": "A6544",
+            "itemTreatment": {
+                "id": "NA",
+                "name": "NA",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 1
+        },
+        "description": {
+            "content": "A6544-EF06466361",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "C",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Corn"
+                    },
+                    {
+                        "content": "VT2RIB",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "EF06466361",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-12",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "2b6096db-3ff7-45b0-9a86-a785e94c6a89",
+        "_rid": "GqBGAMy2ZFUMAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUMAAAAAAAAAA==/",
+        "_etag": "\"7400547f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "AgriGold",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "A64516-VT2RIB",
+            "gtinid": "",
+            "varietyName": "A64516",
+            "productName": "A64516",
+            "itemTreatment": {
+                "id": "NA",
+                "name": "NA",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 1
+        },
+        "description": {
+            "content": "A64516-EF09168506",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "C",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Corn"
+                    },
+                    {
+                        "content": "VT2RIB",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "EF09168506",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-13",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "2884e262-ff29-44a4-a89d-c4f9adee017f",
+        "_rid": "GqBGAMy2ZFUNAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUNAAAAAAAAAA==/",
+        "_etag": "\"7400557f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    },
+    {
+        "typeCode": "seed",
+        "item": {
+            "brandName": "AgriGold",
+            "manufacturerItemIdentification": {
+                "id": "",
+                "typeCode": ""
+            },
+            "manufacturingParty": {
+                "id": "34343401245"
+            },
+            "description": "A64259-VT2RIB",
+            "gtinid": "",
+            "varietyName": "A64259",
+            "productName": "A64259",
+            "itemTreatment": {
+                "id": "NA",
+                "name": "NA",
+                "substance": [
+                    {
+                        "typeCode": "active_ingredient",
+                        "id": "Ethaboxam",
+                        "name": "Ethaboxam Fungicide",
+                        "quantity": [
+                            {
+                                "content": 22.154545,
+                                "typeCode": "Actual",
+                                "unitCode": "PCT"
+                            }
+                        ],
+                        "registrationStatus": [
+                            {
+                                "id": {
+                                    "content": "162650-77-3",
+                                    "schemeAgencyId": "Chemical Abstracts Service",
+                                    "typeCode": "CAS"
+                                },
+                                "effectiveTimePeriod": {
+                                    "endDateTime": "2030-07-01"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "quantity": {
+            "unitCode": "Bags",
+            "content": 1
+        },
+        "description": {
+            "content": "A64259-II36062097",
+            "typeCode": "mics_display"
+        },
+        "classification": {
+            "codes": {
+                "code": [
+                    {
+                        "content": "C",
+                        "listAgencyId": "AGIIS",
+                        "typeCode": "Corn"
+                    },
+                    {
+                        "content": "VT2RIB",
+                        "typeCode": "Trait"
+                    }
+                ]
+            },
+            "typeCode": "Crop"
+        },
+        "lot": {
+            "id": {
+                "content": "II36062097",
+                "typeCode": "Lot"
+            }
+        },
+        "shipmentReference": {
+            "id": "7302",
+            "lineNumberId": "7302-14",
+            "shipUnitReference": {
+                "typeCode": "Semi-Trailer",
+                "id": {
+                    "content": "12345678",
+                    "typeCode": " USDOT_Number"
+                }
+            },
+            "actualShipDateTime": "2022-04-19T00:00:00.000-05:00",
+            "actualDeliveryDateTime": "",
+            "shipFromParty": {
+                "typeCode": "Retailer",
+                "id": "",
+                "name": "SSI Ag Supply & Services - North Plant",
+                "location": {
+                    "name": "",
+                    "glnid": "1369458675000"
+                }
+            },
+            "shipToParty": {
+                "typeCode": "Farmer",
+                "name": "Jeremy Wilson",
+                "accountId": "13",
+                "location": {
+                    "address": {
+                        "addressLine": [
+                            ""
+                        ],
+                        "cityName": "",
+                        "countrySubDivisionCode": {
+                            "content": "",
+                            "typeCode": "State"
+                        },
+                        "postalCode": "45677"
+                    },
+                    "glnid": "null"
+                }
+            },
+            "carrierParty": {
+                "id": "Fleet",
+                "scacid": "NA",
+                "name": "Retailer Fleet"
+            }
+        },
+        "id": "2ab18a0d-a274-4f4a-874c-308fc8c10402",
+        "_rid": "GqBGAMy2ZFUOAAAAAAAAAA==",
+        "_self": "dbs/GqBGAA==/colls/GqBGAMy2ZFU=/docs/GqBGAMy2ZFUOAAAAAAAAAA==/",
+        "_etag": "\"7400567f-0000-0300-0000-658c92460000\"",
+        "_attachments": "attachments/",
+        "_ts": 1703711302
+    }
+]

--- a/sampleV4Files/shippedItemInstanceSwaggerGeneratedV4.json
+++ b/sampleV4Files/shippedItemInstanceSwaggerGeneratedV4.json
@@ -1,0 +1,207 @@
+[
+    {
+      "typeCode": "SEED",
+      "id": "0-539f82b1-df6e-11e9-b486-5ce0c51e62ce",
+      "uid": {
+        "content": "0-539f82b1-df6e-11e9-b486-5ce0c51e62ce",
+        "schemeId": "DataMatrix",
+        "schemeAgencyId": "GS1",
+        "typeCode": "AgGateway"
+      },
+      "lot": {
+        "typeCode": "Lot",
+        "id": "769MXJ4JX",
+        "serialNumberId": [
+          "c93b67b1-b62e-45b4-96fe-1277a341dc0d", "1bcb9bc3-bee6-4bd9-b62b-3e5ac470d8d1"
+        ]
+      },
+      "item": {
+        "relatedId": [
+          {
+            "typeCode": "GTIN_URI",
+            "id": "https://api.agiis.org/?gtinid=00888346580291",
+            "sourceId": "AGIIS",
+            "partyId": "AgGateway"
+          }
+        ],
+        "manufacturerItemIdentification": {
+          "typeCode": "SKU",
+          "id": "34323656565"
+        },
+        "upcid": "888346580291",
+        "gtinid": "00888346580291",
+        "description": "VT DoublePro RIB Complete Relative Maturity 85 days",
+        "classification": {
+          "typeCode": "Crop",
+          "codes": {
+            "code": [
+              {
+                "content": "Corn",
+                "listAgencyId": "USDA",
+                "typeCode": "CropType"
+              },
+              {
+                "content": "C",
+                "listAgencyId": "AGIIS",
+                "typeCode": "Corn"
+              },
+              {
+                "content": "VT2RIB",
+                "typeCode": "Trait"
+              }
+            ]
+          }
+        },
+        "substance": [
+          {
+            "name": "Ammonium Polyphosphate ",
+            "registrationStatus": [
+              {
+                "id": {
+                  "content": "68333-79-9",
+                  "typeCode": "CAS",
+                  "schemeAgencyId": "Chemical Abstract Service"
+                },
+                "effectiveTimePeriod": {
+                  "endDateTime": "2030-07-01"
+                }
+              }
+            ]
+          }
+        ],
+        "packaging": {
+          "perPackageQuantity": {
+            "content": 55,
+            "unitCode": "LB"
+          }
+        },
+        "manufacturingParty": {
+          "id": "34343401245",
+          "name": "WinField United"
+        },
+        "productName": "CP2585",
+        "brandName": "CROPLAN",
+        "varietyName": "VT2P/RIB",
+        "itemTreatment": {
+          "id": "1001339",
+          "typeCode": "Fungicide",
+          "name": "Fortivent® Plus",
+          "substance": [
+            {
+              "typeCode": "active_ingredient",
+              "id": "Ethaboxam",
+              "name": "Ethaboxam Fungicide",
+              "registrationStatus": [
+                {
+                  "id": {
+                    "content": "162650-77-3",
+                    "schemeAgencyId": "Chemical Abstracts Service",
+                    "typeCode": "CAS"
+                  },
+                  "effectiveTimePeriod": {
+                    "endDateTime": "2030-07-01"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "quantity": {
+        "content": 45,
+        "unitCode": "BG"
+      },
+      "packaging": {
+        "typeCode": "SeedBox",
+        "id": "844f95ac-422a-406a-91c5-65d017de2f09",
+        "quantity": {
+          "content": 2475,
+          "typeCode": "GrossWeight",
+          "unitCode": "LB"
+        }
+      },
+      "results": {
+        "quantitative": {
+          "measurement": [
+            {
+              "typeCode": "Operational",
+              "name": "SeedCount",
+              "dateTime": "2021-02-08T13:17:45.034-05:00",
+              "measure": 892,
+              "unitCode": "count/bg"
+            }
+          ]
+        }
+      },
+      "displayName": "CP2585-769MXJ4JX",
+      "shipmentReference": {
+        "id": "34343535",
+        "status": {
+          "code": "In-Transit",
+          "reasonCode": "",
+          "reason": ""
+        },
+        "lineNumberId": "34343535-1",
+        "shipUnitReference": {
+          "typeCode": "Semi-Trailer",
+          "id": {
+            "content": "12345678",
+            "typeCode": "USDOT_Number"
+          }
+        },
+        "actualPickupDateTime": "",
+        "actualShipDateTime": "2022-04-25T09:06:07-05:00",
+        "actualDeliveryDateTime": "",
+        "deliveredQuantity": {
+          "content": null,
+          "unitCode": ""
+        },
+        "acceptedQuantity": {
+          "content": null,
+          "unitCode": ""
+        },
+        "rejectedQuantity": {
+          "content": null,
+          "unitCode": ""
+        },
+        "returnedQuantity": {
+          "content": null,
+          "unitCode": ""
+        },
+        "returnMaterialAuthorizationId": "",
+        "shipFromParty": {
+          "typeCode": "retailer",
+          "id": "1",
+          "name": "Ceres Solutions",
+          "location": {
+            "name": "New Lebanon Seed Hub",
+            "glnid": "1100028417954"
+          }
+        },
+        "shipToParty": {
+          "typeCode": "Farmer",
+          "name": "Farmer Bob",
+          "accountId": "12345",
+          "location": {
+            "address": {
+              "addressLine": [
+                "1234 County Road 5"
+              ],
+              "cityName": "FarmTown",
+              "countrySubDivisionCode": {
+                "content": "IA",
+                "typeCode": "State"
+              },
+              "postalCode": "45677"
+            },
+            "glnid": "NA"
+          }
+        },
+        "carrierParty": {
+          "id": "Fleet",
+          "name": "Ceres Fleet",
+          "scacid": "NA"
+        }
+      }
+    }
+  ]


### PR DESCRIPTION
@knelson-farmbeltnorth  please consider merging this into your original converter function app and deploying to your Azure resource group.  I have include a sample JSON used for testing the SII plugin.
I believe the file location error on framework-to-standard-type-mappings.json will be present as well.

The ISO plugin and the ADM representations have file location override get set methods, whereas it seems these are not available in the ADAPT Standard Plugin.   
<img width="1083" height="291" alt="image" src="https://github.com/user-attachments/assets/e549c63b-a2b4-44be-be16-222e217c1827" />


Something like the following ...

```
AgGateway.ADAPT.StandardPlugin.TypeMappingsFileLocation = System.IO.Path.Combine(executionContext.FunctionDirectory, ".", "framework-to-standard-type-mappings.json") ;
// not sure if this is needed
AgGateway.ADAPT.StandardPlugin.StandardDataTypesFileLocation =  System.IO.Path.Combine(executionContext.FunctionDirectory, ".", "adapt-data-type-definitions.json");
// other resources needed?

```
Another method besides executionContext is application variables, but the variable still needs to be public in the plugin.

 

